### PR TITLE
Expand docfx dependency coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin
+obj
+*.sln

--- a/DocFxParser.csproj
+++ b/DocFxParser.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.30.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
+  </ItemGroup>
+</Project>

--- a/DocFxParser.csproj
+++ b/DocFxParser.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.30.7" />
+    <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
 </Project>

--- a/DocfxDependencyParser.cs
+++ b/DocfxDependencyParser.cs
@@ -10,6 +10,46 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace DocFxParser;
 
+/// <summary>
+/// Callback interface for file access operations.
+/// Implement this to control how the parser accesses files.
+/// </summary>
+public interface IFileAccessCallback
+{
+    /// <summary>
+    /// Called before a file is read. Return true to allow reading, false to skip.
+    /// </summary>
+    /// <param name="filePath">The full path to the file that will be read</param>
+    /// <param name="purpose">The purpose of the file read (e.g., "config", "content", "toc", "markdown", etc.)</param>
+    /// <returns>True to allow the file to be read, false to skip it</returns>
+    bool OnBeforeFileRead(string filePath, string purpose);
+
+    /// <summary>
+    /// Called after a file has been successfully read.
+    /// </summary>
+    /// <param name="filePath">The full path to the file that was read</param>
+    /// <param name="purpose">The purpose of the file read</param>
+    void OnAfterFileRead(string filePath, string purpose);
+
+    /// <summary>
+    /// Called when a file read fails.
+    /// </summary>
+    /// <param name="filePath">The full path to the file that failed to read</param>
+    /// <param name="purpose">The purpose of the file read</param>
+    /// <param name="exception">The exception that occurred</param>
+    void OnFileReadError(string filePath, string purpose, Exception exception);
+}
+
+/// <summary>
+/// Default implementation that allows all file operations.
+/// </summary>
+public class DefaultFileAccessCallback : IFileAccessCallback
+{
+    public bool OnBeforeFileRead(string filePath, string purpose) => true;
+    public void OnAfterFileRead(string filePath, string purpose) { }
+    public void OnFileReadError(string filePath, string purpose, Exception exception) { }
+}
+
 public class DocfxDependencyParser
 {
     private static readonly string[] MarkdownExtensions = new[] { ".md" };
@@ -18,10 +58,16 @@ public class DocfxDependencyParser
     private static readonly string[] TocFileNames = new[] { "toc.yml", "toc.yaml", "toc.md" };
 
     private readonly MarkdownPipeline _markdownPipeline;
+    private readonly IFileAccessCallback _fileAccessCallback;
 
-    public DocfxDependencyParser()
+    public DocfxDependencyParser() : this(new DefaultFileAccessCallback())
+    {
+    }
+
+    public DocfxDependencyParser(IFileAccessCallback fileAccessCallback)
     {
         _markdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+        _fileAccessCallback = fileAccessCallback ?? throw new ArgumentNullException(nameof(fileAccessCallback));
     }
 
     public DocfxDependencyResult Collect(string docfxConfigPath)
@@ -101,7 +147,7 @@ public class DocfxDependencyParser
 
                 foreach (var candidate in ExpandAdditionalEntry(entry, configDirectory))
                 {
-                    if (File.Exists(candidate))
+                    if (FileExistsWithCallback(candidate, sourceType))
                     {
                         RegisterFile(candidate, sourceType);
                     }
@@ -109,7 +155,10 @@ public class DocfxDependencyParser
                     {
                         foreach (var file in Directory.EnumerateFiles(candidate, "*", SearchOption.AllDirectories))
                         {
-                            RegisterFile(file, sourceType);
+                            if (_fileAccessCallback.OnBeforeFileRead(file, sourceType))
+                            {
+                                RegisterFile(file, sourceType);
+                            }
                         }
                     }
                 }
@@ -135,7 +184,11 @@ public class DocfxDependencyParser
             }
             else if (HtmlExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
             {
-                dependency.References = ExtractHtmlReferences(File.ReadAllText(fullPath), Path.GetDirectoryName(fullPath)!, configDirectory, knownFiles);
+                var htmlContent = ReadFileWithCallback(fullPath, "html");
+                if (htmlContent != null)
+                {
+                    dependency.References = ExtractHtmlReferences(htmlContent, Path.GetDirectoryName(fullPath)!, configDirectory, knownFiles);
+                }
             }
         }
 
@@ -147,19 +200,69 @@ public class DocfxDependencyParser
         };
     }
 
-    private static DocfxConfig LoadConfiguration(string configPath)
+    /// <summary>
+    /// Safely read a file with callback notification.
+    /// </summary>
+    private string? ReadFileWithCallback(string filePath, string purpose)
     {
-        using var stream = File.OpenRead(configPath);
-        using var reader = new StreamReader(stream);
-        using var jsonReader = new JsonTextReader(reader);
-        var serializer = new JsonSerializer();
-        var config = serializer.Deserialize<DocfxConfig>(jsonReader);
-        if (config == null)
+        if (!_fileAccessCallback.OnBeforeFileRead(filePath, purpose))
         {
-            throw new InvalidOperationException("The docfx.json file could not be deserialized.");
+            return null;
         }
 
-        return config;
+        try
+        {
+            var content = File.ReadAllText(filePath);
+            _fileAccessCallback.OnAfterFileRead(filePath, purpose);
+            return content;
+        }
+        catch (Exception ex)
+        {
+            _fileAccessCallback.OnFileReadError(filePath, purpose, ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Check if a file exists and notify callback before accessing.
+    /// </summary>
+    private bool FileExistsWithCallback(string filePath, string purpose)
+    {
+        if (!_fileAccessCallback.OnBeforeFileRead(filePath, purpose))
+        {
+            return false;
+        }
+
+        return File.Exists(filePath);
+    }
+
+    private DocfxConfig LoadConfiguration(string configPath)
+    {
+        if (!_fileAccessCallback.OnBeforeFileRead(configPath, "config"))
+        {
+            throw new InvalidOperationException($"File access denied by callback: {configPath}");
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(configPath);
+            using var reader = new StreamReader(stream);
+            using var jsonReader = new JsonTextReader(reader);
+            var serializer = new JsonSerializer();
+            var config = serializer.Deserialize<DocfxConfig>(jsonReader);
+            if (config == null)
+            {
+                throw new InvalidOperationException("The docfx.json file could not be deserialized.");
+            }
+
+            _fileAccessCallback.OnAfterFileRead(configPath, "config");
+            return config;
+        }
+        catch (Exception ex)
+        {
+            _fileAccessCallback.OnFileReadError(configPath, "config", ex);
+            throw;
+        }
     }
 
     private static IEnumerable<string> ExpandMapping(FileMappingItem mapping, string configDirectory, List<string>? globalExclude = null)
@@ -273,7 +376,12 @@ public class DocfxDependencyParser
 
     private List<string> ExtractMarkdownReferences(string markdownPath, string docsetRoot, IDictionary<string, FileDependency> knownFiles)
     {
-        var content = File.ReadAllText(markdownPath);
+        var content = ReadFileWithCallback(markdownPath, "markdown");
+        if (content == null)
+        {
+            return new List<string>();
+        }
+
         var document = Markdig.Markdown.Parse(content, _markdownPipeline);
         var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var baseDirectory = Path.GetDirectoryName(markdownPath)!;
@@ -351,17 +459,20 @@ public class DocfxDependencyParser
         if (fileName.Equals("toc.md", StringComparison.OrdinalIgnoreCase))
         {
             // Parse markdown TOC
-            var content = File.ReadAllText(tocPath);
-            var document = Markdig.Markdown.Parse(content, _markdownPipeline);
-
-            foreach (var link in document.Descendants<LinkInline>())
+            var content = ReadFileWithCallback(tocPath, "toc");
+            if (content != null)
             {
-                if (string.IsNullOrEmpty(link.Url))
-                {
-                    continue;
-                }
+                var document = Markdig.Markdown.Parse(content, _markdownPipeline);
 
-                ProcessTocReference(link.Url, baseDirectory, docsetRoot, knownFiles, references);
+                foreach (var link in document.Descendants<LinkInline>())
+                {
+                    if (string.IsNullOrEmpty(link.Url))
+                    {
+                        continue;
+                    }
+
+                    ProcessTocReference(link.Url, baseDirectory, docsetRoot, knownFiles, references);
+                }
             }
         }
         else if (fileName.Equals("toc.yml", StringComparison.OrdinalIgnoreCase) || 
@@ -370,16 +481,19 @@ public class DocfxDependencyParser
             // Parse YAML TOC
             try
             {
-                var yaml = File.ReadAllText(tocPath);
-                var deserializer = new DeserializerBuilder()
-                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                    .IgnoreUnmatchedProperties()
-                    .Build();
-
-                var tocItems = deserializer.Deserialize<List<TocItem>>(yaml);
-                if (tocItems != null)
+                var yaml = ReadFileWithCallback(tocPath, "toc");
+                if (yaml != null)
                 {
-                    ProcessTocItems(tocItems, baseDirectory, docsetRoot, knownFiles, references);
+                    var deserializer = new DeserializerBuilder()
+                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                        .IgnoreUnmatchedProperties()
+                        .Build();
+
+                    var tocItems = deserializer.Deserialize<List<TocItem>>(yaml);
+                    if (tocItems != null)
+                    {
+                        ProcessTocItems(tocItems, baseDirectory, docsetRoot, knownFiles, references);
+                    }
                 }
             }
             catch (Exception)

--- a/DocfxDependencyParser.cs
+++ b/DocfxDependencyParser.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using HtmlAgilityPack;
 using Markdig;
 using Markdig.Syntax;
@@ -6,13 +5,17 @@ using Markdig.Syntax.Inlines;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Newtonsoft.Json;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace DocFxParser;
 
 public class DocfxDependencyParser
 {
-    private static readonly string[] MarkdownExtensions = new[] { ".md", ".markdown", ".mdown", ".mkd" };
+    private static readonly string[] MarkdownExtensions = new[] { ".md" };
     private static readonly string[] HtmlExtensions = new[] { ".html", ".htm" };
+    private static readonly string[] YamlExtensions = new[] { ".yaml", ".yml" };
+    private static readonly string[] TocFileNames = new[] { "toc.yml", "toc.yaml", "toc.md" };
 
     private readonly MarkdownPipeline _markdownPipeline;
 
@@ -67,7 +70,7 @@ public class DocfxDependencyParser
 
             foreach (var mapping in mappings)
             {
-                foreach (var match in ExpandMapping(mapping, configDirectory))
+                foreach (var match in ExpandMapping(mapping, configDirectory, config.Build?.Exclude))
                 {
                     RegisterFile(match, sourceType);
                 }
@@ -120,8 +123,13 @@ public class DocfxDependencyParser
             var fullPath = kvp.Key;
             var dependency = kvp.Value;
             var extension = Path.GetExtension(fullPath);
+            var fileName = Path.GetFileName(fullPath);
 
-            if (MarkdownExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            if (IsTocFile(fileName))
+            {
+                dependency.References = ExtractTocReferences(fullPath, configDirectory, knownFiles);
+            }
+            else if (MarkdownExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
             {
                 dependency.References = ExtractMarkdownReferences(fullPath, configDirectory, knownFiles);
             }
@@ -154,7 +162,7 @@ public class DocfxDependencyParser
         return config;
     }
 
-    private static IEnumerable<string> ExpandMapping(FileMappingItem mapping, string configDirectory)
+    private static IEnumerable<string> ExpandMapping(FileMappingItem mapping, string configDirectory, List<string>? globalExclude = null)
     {
         var includes = mapping.Files ?? new List<string>();
         if (includes.Count == 0)
@@ -178,6 +186,16 @@ public class DocfxDependencyParser
             matcher.AddInclude(include);
         }
 
+        // Apply global exclude rules first
+        if (globalExclude != null)
+        {
+            foreach (var exclude in globalExclude)
+            {
+                matcher.AddExclude(exclude);
+            }
+        }
+
+        // Apply mapping-specific exclude rules
         if (mapping.Exclude != null)
         {
             foreach (var exclude in mapping.Exclude)
@@ -319,6 +337,149 @@ public class DocfxDependencyParser
             .ToList();
     }
 
+    private static bool IsTocFile(string fileName)
+    {
+        return TocFileNames.Contains(fileName, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private List<string> ExtractTocReferences(string tocPath, string docsetRoot, IDictionary<string, FileDependency> knownFiles)
+    {
+        var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var baseDirectory = Path.GetDirectoryName(tocPath)!;
+        var fileName = Path.GetFileName(tocPath);
+
+        if (fileName.Equals("toc.md", StringComparison.OrdinalIgnoreCase))
+        {
+            // Parse markdown TOC
+            var content = File.ReadAllText(tocPath);
+            var document = Markdig.Markdown.Parse(content, _markdownPipeline);
+
+            foreach (var link in document.Descendants<LinkInline>())
+            {
+                if (string.IsNullOrEmpty(link.Url))
+                {
+                    continue;
+                }
+
+                ProcessTocReference(link.Url, baseDirectory, docsetRoot, knownFiles, references);
+            }
+        }
+        else if (fileName.Equals("toc.yml", StringComparison.OrdinalIgnoreCase) || 
+                 fileName.Equals("toc.yaml", StringComparison.OrdinalIgnoreCase))
+        {
+            // Parse YAML TOC
+            try
+            {
+                var yaml = File.ReadAllText(tocPath);
+                var deserializer = new DeserializerBuilder()
+                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                    .IgnoreUnmatchedProperties()
+                    .Build();
+
+                var tocItems = deserializer.Deserialize<List<TocItem>>(yaml);
+                if (tocItems != null)
+                {
+                    ProcessTocItems(tocItems, baseDirectory, docsetRoot, knownFiles, references);
+                }
+            }
+            catch (Exception)
+            {
+                // If YAML parsing fails, skip this file
+            }
+        }
+
+        return references
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private void ProcessTocItems(List<TocItem> items, string baseDirectory, string docsetRoot, IDictionary<string, FileDependency> knownFiles, HashSet<string> references)
+    {
+        foreach (var item in items)
+        {
+            // Process href (can be a file or another toc)
+            if (!string.IsNullOrEmpty(item.Href))
+            {
+                ProcessTocReference(item.Href, baseDirectory, docsetRoot, knownFiles, references);
+            }
+
+            // Process topicHref (the landing page for a folder with a toc)
+            if (!string.IsNullOrEmpty(item.TopicHref))
+            {
+                ProcessTocReference(item.TopicHref, baseDirectory, docsetRoot, knownFiles, references);
+            }
+
+            // Process homepage
+            if (!string.IsNullOrEmpty(item.Homepage))
+            {
+                ProcessTocReference(item.Homepage, baseDirectory, docsetRoot, knownFiles, references);
+            }
+
+            // Recursively process child items
+            if (item.Items != null && item.Items.Count > 0)
+            {
+                ProcessTocItems(item.Items, baseDirectory, docsetRoot, knownFiles, references);
+            }
+        }
+    }
+
+    private void ProcessTocReference(string href, string baseDirectory, string docsetRoot, IDictionary<string, FileDependency> knownFiles, HashSet<string> references)
+    {
+        var sanitized = SanitizeUrl(href);
+        if (string.IsNullOrEmpty(sanitized))
+        {
+            return;
+        }
+
+        // First, try to resolve as a direct file reference
+        foreach (var resolved in ResolveLinkTargets(sanitized, baseDirectory, docsetRoot, knownFiles))
+        {
+            references.Add(resolved);
+        }
+
+        // If the href is a directory reference, look for toc files in that directory
+        var candidatePaths = new List<string>();
+        
+        if (sanitized.StartsWith("~/", StringComparison.Ordinal))
+        {
+            var relative = sanitized.Substring(2).TrimEnd('/');
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(docsetRoot, NormalizeForPath(relative))));
+        }
+        else if (sanitized.StartsWith("/", StringComparison.Ordinal))
+        {
+            var relative = sanitized.TrimStart('/').TrimEnd('/');
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(docsetRoot, NormalizeForPath(relative))));
+        }
+        else if (Path.IsPathRooted(sanitized))
+        {
+            candidatePaths.Add(Path.GetFullPath(NormalizeForPath(sanitized)));
+        }
+        else
+        {
+            var relative = NormalizeForPath(sanitized).TrimEnd(Path.DirectorySeparatorChar);
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(baseDirectory, relative)));
+        }
+
+        // Check if any candidate is a directory and look for TOC files
+        foreach (var candidatePath in candidatePaths)
+        {
+            if (Directory.Exists(candidatePath))
+            {
+                foreach (var tocFileName in TocFileNames)
+                {
+                    var tocPath = Path.Combine(candidatePath, tocFileName);
+                    var normalized = NormalizeFullPath(tocPath);
+                    
+                    if (knownFiles.TryGetValue(normalized, out var dependency))
+                    {
+                        references.Add(dependency.Path);
+                    }
+                }
+            }
+        }
+    }
+
     private IEnumerable<string> ResolveLinkTargets(string url, string baseDirectory, string docsetRoot, IDictionary<string, FileDependency> knownFiles)
     {
         var sanitized = SanitizeUrl(url);
@@ -392,6 +553,12 @@ public class DocfxDependencyParser
 
     private static string DetermineFileType(string path)
     {
+        var fileName = Path.GetFileName(path);
+        if (IsTocFile(fileName))
+        {
+            return "toc";
+        }
+
         var extension = Path.GetExtension(path);
         if (MarkdownExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
         {
@@ -403,7 +570,7 @@ public class DocfxDependencyParser
             return "html";
         }
 
-        if (extension.Equals(".yml", StringComparison.OrdinalIgnoreCase) || extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase))
+        if (YamlExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
         {
             return "yaml";
         }

--- a/DocfxDependencyParser.cs
+++ b/DocfxDependencyParser.cs
@@ -1,0 +1,435 @@
+using System.Linq;
+using HtmlAgilityPack;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+using Newtonsoft.Json;
+
+namespace DocFxParser;
+
+public class DocfxDependencyParser
+{
+    private static readonly string[] MarkdownExtensions = new[] { ".md", ".markdown", ".mdown", ".mkd" };
+    private static readonly string[] HtmlExtensions = new[] { ".html", ".htm" };
+
+    private readonly MarkdownPipeline _markdownPipeline;
+
+    public DocfxDependencyParser()
+    {
+        _markdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+    }
+
+    public DocfxDependencyResult Collect(string docfxConfigPath)
+    {
+        if (string.IsNullOrWhiteSpace(docfxConfigPath))
+        {
+            throw new ArgumentException("Configuration path cannot be null or empty", nameof(docfxConfigPath));
+        }
+
+        var fullConfigPath = Path.GetFullPath(docfxConfigPath);
+        if (!File.Exists(fullConfigPath))
+        {
+            throw new FileNotFoundException("docfx.json not found", fullConfigPath);
+        }
+
+        var configDirectory = Path.GetDirectoryName(fullConfigPath)!;
+        var config = LoadConfiguration(fullConfigPath);
+
+        var files = new Dictionary<string, FileDependency>(StringComparer.OrdinalIgnoreCase);
+
+        void RegisterFile(string fullPath, string sourceType)
+        {
+            var normalizedPath = NormalizeFullPath(fullPath);
+            if (!files.TryGetValue(normalizedPath, out var dependency))
+            {
+                dependency = new FileDependency
+                {
+                    Path = ToOutputPath(configDirectory, normalizedPath),
+                    FileType = DetermineFileType(normalizedPath)
+                };
+                files.Add(normalizedPath, dependency);
+            }
+
+            if (!dependency.SourceTypes.Any(st => st.Equals(sourceType, StringComparison.OrdinalIgnoreCase)))
+            {
+                dependency.SourceTypes.Add(sourceType);
+            }
+        }
+
+        void CollectFromMapping(IEnumerable<FileMappingItem>? mappings, string sourceType)
+        {
+            if (mappings == null)
+            {
+                return;
+            }
+
+            foreach (var mapping in mappings)
+            {
+                foreach (var match in ExpandMapping(mapping, configDirectory))
+                {
+                    RegisterFile(match, sourceType);
+                }
+            }
+        }
+
+        CollectFromMapping(config.Build?.Content, "content");
+        CollectFromMapping(config.Build?.Resource, "resource");
+        CollectFromMapping(config.Build?.Overwrite, "overwrite");
+
+        CollectAdditionalFiles(config.Build?.GlobalMetadataFiles, "globalMetadata");
+        CollectAdditionalFiles(config.Build?.FileMetadataFiles, "fileMetadata");
+        CollectAdditionalFiles(config.Build?.Template, "template");
+
+        void CollectAdditionalFiles(IEnumerable<string>? entries, string sourceType)
+        {
+            if (entries == null)
+            {
+                return;
+            }
+
+            foreach (var entry in entries)
+            {
+                if (string.IsNullOrWhiteSpace(entry))
+                {
+                    continue;
+                }
+
+                foreach (var candidate in ExpandAdditionalEntry(entry, configDirectory))
+                {
+                    if (File.Exists(candidate))
+                    {
+                        RegisterFile(candidate, sourceType);
+                    }
+                    else if (Directory.Exists(candidate))
+                    {
+                        foreach (var file in Directory.EnumerateFiles(candidate, "*", SearchOption.AllDirectories))
+                        {
+                            RegisterFile(file, sourceType);
+                        }
+                    }
+                }
+            }
+        }
+
+        var knownFiles = new Dictionary<string, FileDependency>(files, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var kvp in knownFiles)
+        {
+            var fullPath = kvp.Key;
+            var dependency = kvp.Value;
+            var extension = Path.GetExtension(fullPath);
+
+            if (MarkdownExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            {
+                dependency.References = ExtractMarkdownReferences(fullPath, configDirectory, knownFiles);
+            }
+            else if (HtmlExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            {
+                dependency.References = ExtractHtmlReferences(File.ReadAllText(fullPath), Path.GetDirectoryName(fullPath)!, configDirectory, knownFiles);
+            }
+        }
+
+        return new DocfxDependencyResult
+        {
+            Files = files.Values
+                .OrderBy(f => f.Path, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+        };
+    }
+
+    private static DocfxConfig LoadConfiguration(string configPath)
+    {
+        using var stream = File.OpenRead(configPath);
+        using var reader = new StreamReader(stream);
+        using var jsonReader = new JsonTextReader(reader);
+        var serializer = new JsonSerializer();
+        var config = serializer.Deserialize<DocfxConfig>(jsonReader);
+        if (config == null)
+        {
+            throw new InvalidOperationException("The docfx.json file could not be deserialized.");
+        }
+
+        return config;
+    }
+
+    private static IEnumerable<string> ExpandMapping(FileMappingItem mapping, string configDirectory)
+    {
+        var includes = mapping.Files ?? new List<string>();
+        if (includes.Count == 0)
+        {
+            yield break;
+        }
+
+        var src = mapping.Src;
+        var baseDirectory = string.IsNullOrWhiteSpace(src)
+            ? configDirectory
+            : Path.GetFullPath(Path.Combine(configDirectory, src));
+
+        if (!Directory.Exists(baseDirectory))
+        {
+            yield break;
+        }
+
+        var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+        foreach (var include in includes)
+        {
+            matcher.AddInclude(include);
+        }
+
+        if (mapping.Exclude != null)
+        {
+            foreach (var exclude in mapping.Exclude)
+            {
+                matcher.AddExclude(exclude);
+            }
+        }
+
+        var directoryInfo = new DirectoryInfo(baseDirectory);
+        if (!directoryInfo.Exists)
+        {
+            yield break;
+        }
+
+        var result = matcher.Execute(new DirectoryInfoWrapper(directoryInfo));
+        foreach (var file in result.Files)
+        {
+            var combined = Path.Combine(baseDirectory, file.Path);
+            yield return Path.GetFullPath(combined);
+        }
+    }
+
+    private static IEnumerable<string> ExpandAdditionalEntry(string entry, string configDirectory)
+    {
+        var trimmed = entry.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            yield break;
+        }
+
+        var relativeCandidate = trimmed.StartsWith("~/", StringComparison.Ordinal)
+            ? trimmed.Substring(2)
+            : trimmed;
+
+        var normalized = NormalizeForPath(relativeCandidate);
+
+        if (ContainsGlobCharacters(normalized))
+        {
+            var directoryInfo = new DirectoryInfo(configDirectory);
+            if (!directoryInfo.Exists)
+            {
+                yield break;
+            }
+
+            var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+            matcher.AddInclude(normalized);
+            var result = matcher.Execute(new DirectoryInfoWrapper(directoryInfo));
+            foreach (var file in result.Files)
+            {
+                yield return Path.GetFullPath(Path.Combine(configDirectory, file.Path));
+            }
+
+            yield break;
+        }
+
+        if (trimmed.StartsWith("~/", StringComparison.Ordinal))
+        {
+            yield return Path.GetFullPath(Path.Combine(configDirectory, normalized));
+            yield break;
+        }
+
+        if (Path.IsPathRooted(trimmed))
+        {
+            yield return Path.GetFullPath(NormalizeForPath(trimmed));
+            yield break;
+        }
+
+        yield return Path.GetFullPath(Path.Combine(configDirectory, normalized));
+    }
+
+    private static bool ContainsGlobCharacters(string value)
+    {
+        return value.IndexOfAny(new[] { '*', '?', '[', ']' }) >= 0;
+    }
+
+    private List<string> ExtractMarkdownReferences(string markdownPath, string docsetRoot, IDictionary<string, FileDependency> knownFiles)
+    {
+        var content = File.ReadAllText(markdownPath);
+        var document = Markdig.Markdown.Parse(content, _markdownPipeline);
+        var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var baseDirectory = Path.GetDirectoryName(markdownPath)!;
+
+        foreach (var link in document.Descendants<LinkInline>())
+        {
+            if (string.IsNullOrEmpty(link.Url))
+            {
+                continue;
+            }
+
+            foreach (var resolved in ResolveLinkTargets(link.Url, baseDirectory, docsetRoot, knownFiles))
+            {
+                references.Add(resolved);
+            }
+        }
+
+        var html = Markdig.Markdown.ToHtml(content, _markdownPipeline);
+        references.UnionWith(ExtractHtmlReferences(html, baseDirectory, docsetRoot, knownFiles));
+
+        return references
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private List<string> ExtractHtmlReferences(string htmlContent, string baseDirectory, string docsetRoot, IDictionary<string, FileDependency> knownFiles)
+    {
+        var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var document = new HtmlDocument();
+        document.LoadHtml(htmlContent);
+
+        var nodes = document.DocumentNode.SelectNodes("//*[@href or @src]");
+        if (nodes == null)
+        {
+            return new List<string>();
+        }
+
+        foreach (var node in nodes)
+        {
+            if (node.Attributes["href"] != null)
+            {
+                foreach (var resolved in ResolveLinkTargets(node.Attributes["href"].Value, baseDirectory, docsetRoot, knownFiles))
+                {
+                    references.Add(resolved);
+                }
+            }
+
+            if (node.Attributes["src"] != null)
+            {
+                foreach (var resolved in ResolveLinkTargets(node.Attributes["src"].Value, baseDirectory, docsetRoot, knownFiles))
+                {
+                    references.Add(resolved);
+                }
+            }
+        }
+
+        return references
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private IEnumerable<string> ResolveLinkTargets(string url, string baseDirectory, string docsetRoot, IDictionary<string, FileDependency> knownFiles)
+    {
+        var sanitized = SanitizeUrl(url);
+        if (string.IsNullOrEmpty(sanitized))
+        {
+            yield break;
+        }
+
+        if (Uri.TryCreate(sanitized, UriKind.Absolute, out var absoluteUri) && !string.Equals(absoluteUri.Scheme, "file", StringComparison.OrdinalIgnoreCase))
+        {
+            yield break;
+        }
+
+        var candidatePaths = new List<string>();
+
+        if (sanitized.StartsWith("~/", StringComparison.Ordinal))
+        {
+            var relative = sanitized.Substring(2);
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(docsetRoot, NormalizeForPath(relative))));
+        }
+        else if (sanitized.StartsWith("/", StringComparison.Ordinal))
+        {
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(docsetRoot, NormalizeForPath(sanitized.TrimStart('/')))));
+        }
+        else if (Path.IsPathRooted(sanitized))
+        {
+            candidatePaths.Add(Path.GetFullPath(NormalizeForPath(sanitized)));
+        }
+        else
+        {
+            var relative = NormalizeForPath(sanitized);
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(baseDirectory, relative)));
+            candidatePaths.Add(Path.GetFullPath(Path.Combine(docsetRoot, relative)));
+        }
+
+        foreach (var candidate in candidatePaths)
+        {
+            var normalized = NormalizeFullPath(candidate);
+            if (knownFiles.TryGetValue(normalized, out var dependency))
+            {
+                yield return dependency.Path;
+            }
+        }
+    }
+
+    private static string SanitizeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = url.Trim();
+        if (trimmed.StartsWith("#", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        if (trimmed.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("xref:", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        var withoutAnchor = trimmed.Split('#')[0];
+        var withoutQuery = withoutAnchor.Split('?')[0];
+
+        return Uri.UnescapeDataString(withoutQuery);
+    }
+
+    private static string DetermineFileType(string path)
+    {
+        var extension = Path.GetExtension(path);
+        if (MarkdownExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+        {
+            return "markdown";
+        }
+
+        if (HtmlExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+        {
+            return "html";
+        }
+
+        if (extension.Equals(".yml", StringComparison.OrdinalIgnoreCase) || extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "yaml";
+        }
+
+        if (extension.Equals(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return "json";
+        }
+
+        return "resource";
+    }
+
+    private static string NormalizeFullPath(string path)
+    {
+        return Path.GetFullPath(path);
+    }
+
+    private static string NormalizeForPath(string path)
+    {
+        return path.Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    private static string ToOutputPath(string root, string fullPath)
+    {
+        var relative = Path.GetRelativePath(root, fullPath);
+        var normalized = relative.Replace(Path.DirectorySeparatorChar, '/');
+        return normalized;
+    }
+}

--- a/DocfxModels.cs
+++ b/DocfxModels.cs
@@ -1,0 +1,68 @@
+using Newtonsoft.Json;
+
+namespace DocFxParser;
+
+public class DocfxConfig
+{
+    [JsonProperty("build")]
+    public DocfxBuildConfig? Build { get; set; }
+}
+
+public class DocfxBuildConfig
+{
+    [JsonProperty("content")]
+    public List<FileMappingItem>? Content { get; set; }
+
+    [JsonProperty("resource")]
+    public List<FileMappingItem>? Resource { get; set; }
+
+    [JsonProperty("overwrite")]
+    public List<FileMappingItem>? Overwrite { get; set; }
+
+    [JsonProperty("globalMetadataFiles")]
+    [JsonConverter(typeof(FlexibleStringListConverter))]
+    public List<string>? GlobalMetadataFiles { get; set; }
+
+    [JsonProperty("fileMetadataFiles")]
+    [JsonConverter(typeof(FlexibleStringListConverter))]
+    public List<string>? FileMetadataFiles { get; set; }
+
+    [JsonProperty("template")]
+    [JsonConverter(typeof(FlexibleStringListConverter))]
+    public List<string>? Template { get; set; }
+}
+
+public class FileMappingItem
+{
+    [JsonProperty("files")]
+    [JsonConverter(typeof(FlexibleStringListConverter))]
+    public List<string>? Files { get; set; }
+
+    [JsonProperty("exclude")]
+    [JsonConverter(typeof(FlexibleStringListConverter))]
+    public List<string>? Exclude { get; set; }
+
+    [JsonProperty("src")]
+    public string? Src { get; set; }
+}
+
+public class DocfxDependencyResult
+{
+    [JsonProperty("files")]
+    public List<FileDependency> Files { get; set; } = new();
+}
+
+public class FileDependency
+{
+    [JsonProperty("path")]
+    public string Path { get; set; } = string.Empty;
+
+    [JsonProperty("fileType")]
+    public string FileType { get; set; } = string.Empty;
+
+    [JsonProperty("sourceTypes")]
+    public List<string> SourceTypes { get; set; } = new();
+
+    [JsonProperty("references")]
+    public List<string> References { get; set; } = new();
+}

--- a/DocfxModels.cs
+++ b/DocfxModels.cs
@@ -19,6 +19,10 @@ public class DocfxBuildConfig
     [JsonProperty("overwrite")]
     public List<FileMappingItem>? Overwrite { get; set; }
 
+    [JsonProperty("exclude")]
+    [JsonConverter(typeof(FlexibleStringListConverter))]
+    public List<string>? Exclude { get; set; }
+
     [JsonProperty("globalMetadataFiles")]
     [JsonConverter(typeof(FlexibleStringListConverter))]
     public List<string>? GlobalMetadataFiles { get; set; }
@@ -65,4 +69,22 @@ public class FileDependency
 
     [JsonProperty("references")]
     public List<string> References { get; set; } = new();
+}
+
+public class TocItem
+{
+    [JsonProperty("name")]
+    public string? Name { get; set; }
+
+    [JsonProperty("href")]
+    public string? Href { get; set; }
+
+    [JsonProperty("topicHref")]
+    public string? TopicHref { get; set; }
+
+    [JsonProperty("homepage")]
+    public string? Homepage { get; set; }
+
+    [JsonProperty("items")]
+    public List<TocItem>? Items { get; set; }
 }

--- a/FlexibleStringListConverter.cs
+++ b/FlexibleStringListConverter.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/FlexibleStringListConverter.cs
+++ b/FlexibleStringListConverter.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DocFxParser;
+
+public class FlexibleStringListConverter : JsonConverter<List<string>?>
+{
+    public override void WriteJson(JsonWriter writer, List<string>? value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        serializer.Serialize(writer, value);
+    }
+
+    public override List<string>? ReadJson(JsonReader reader, Type objectType, List<string>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType == JsonToken.String)
+        {
+            var value = reader.Value?.ToString();
+            return string.IsNullOrEmpty(value) ? new List<string>() : new List<string> { value };
+        }
+
+        if (reader.TokenType == JsonToken.StartArray)
+        {
+            var array = JArray.Load(reader);
+            return array.Values<string>().Where(v => !string.IsNullOrEmpty(v)).ToList();
+        }
+
+        throw new JsonSerializationException($"Unexpected token {reader.TokenType} when parsing string list.");
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,29 @@
+using DocFxParser;
+using Newtonsoft.Json;
+
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("Usage: DocFxParser <path-to-docfx.json>");
+    return 1;
+}
+
+var docfxConfigPath = Path.GetFullPath(args[0]);
+if (!File.Exists(docfxConfigPath))
+{
+    Console.Error.WriteLine($"docfx.json not found at '{docfxConfigPath}'");
+    return 1;
+}
+
+try
+{
+    var parser = new DocfxDependencyParser();
+    var result = parser.Collect(docfxConfigPath);
+    var json = JsonConvert.SerializeObject(result, Formatting.Indented);
+    Console.WriteLine(json);
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Failed to parse docfx configuration: {ex.Message}");
+    return 2;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -3,11 +3,19 @@ using Newtonsoft.Json;
 
 if (args.Length == 0)
 {
-    Console.Error.WriteLine("Usage: DocFxParser <path-to-docfx.json>");
+    Console.Error.WriteLine("Usage: DocFxParser <path-to-docfx.json-or-directory>");
     return 1;
 }
 
-var docfxConfigPath = Path.GetFullPath(args[0]);
+var inputPath = Path.GetFullPath(args[0]);
+var docfxConfigPath = inputPath;
+
+// If the path is a directory, append docfx.json
+if (Directory.Exists(inputPath))
+{
+    docfxConfigPath = Path.Combine(inputPath, "docfx.json");
+}
+
 if (!File.Exists(docfxConfigPath))
 {
     Console.Error.WriteLine($"docfx.json not found at '{docfxConfigPath}'");

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-utiltiy for parsing docfx.json files to calculate what files are being used
+# DocFxParser
+
+Utility for parsing `docfx.json` files to determine which files are required to build the documentation set.
+
+## Features
+
+- Parses `docfx.json` using Newtonsoft.Json just like DocFX.
+- Resolves file mappings defined in the `build` section (`content`, `resource`, and `overwrite`) with the `Microsoft.Extensions.FileSystemGlobbing` matcher used by DocFX.
+- Reads Markdown files with the Markdig pipeline to capture Markdown and embedded HTML links.
+- Collects HTML style references (e.g., `<img src="...">`, `<a href="...">`) with HtmlAgilityPack.
+- Produces a JSON report describing every matched file, the source type(s) that include it, its inferred file type, and the local references made inside Markdown/HTML files.
+
+## Usage
+
+```bash
+# Assuming dotnet CLI is available
+dotnet run -- ./path/to/docfx.json
+```
+
+The tool prints a JSON document similar to the following:
+
+```json
+{
+  "files": [
+    {
+      "path": "articles/getting-started.md",
+      "fileType": "markdown",
+      "sourceTypes": ["content"],
+      "references": [
+        "images/overview.png",
+        "includes/snippet.md"
+      ]
+    },
+    {
+      "path": "styles/site.css",
+      "fileType": "resource",
+      "sourceTypes": ["resource"],
+      "references": []
+    }
+  ]
+}
+```
+
+Paths are reported relative to the directory containing `docfx.json`. Files that live outside of that directory (because of the `src` setting) will appear with `../` segments.
+
+## Requirements
+
+- .NET 7 SDK (or newer) to build and run the console application.
+- File system access to the directories referenced by the `src` values inside `docfx.json`.
+- Network access is **not** required; all file resolution happens locally.
+
+## Notes
+
+The parser only reports references that resolve to files declared in the `docfx.json` file mappings. External links (HTTP/HTTPS), anchors, `mailto:` links, and `xref:` references are ignored.

--- a/README.md
+++ b/README.md
@@ -2,53 +2,9 @@
 
 Utility for parsing `docfx.json` files to determine which files are required to build the documentation set.
 
-## Features
-
-- Parses `docfx.json` using Newtonsoft.Json just like DocFX.
-- Resolves file mappings defined in the `build` section (`content`, `resource`, and `overwrite`) with the `Microsoft.Extensions.FileSystemGlobbing` matcher used by DocFX.
-- Reads Markdown files with the Markdig pipeline to capture Markdown and embedded HTML links.
-- Collects HTML style references (e.g., `<img src="...">`, `<a href="...">`) with HtmlAgilityPack.
-- Produces a JSON report describing every matched file, the source type(s) that include it, its inferred file type, and the local references made inside Markdown/HTML files.
-
 ## Usage
 
 ```bash
 # Assuming dotnet CLI is available
 dotnet run -- ./path/to/docfx.json
 ```
-
-The tool prints a JSON document similar to the following:
-
-```json
-{
-  "files": [
-    {
-      "path": "articles/getting-started.md",
-      "fileType": "markdown",
-      "sourceTypes": ["content"],
-      "references": [
-        "images/overview.png",
-        "includes/snippet.md"
-      ]
-    },
-    {
-      "path": "styles/site.css",
-      "fileType": "resource",
-      "sourceTypes": ["resource"],
-      "references": []
-    }
-  ]
-}
-```
-
-Paths are reported relative to the directory containing `docfx.json`. Files that live outside of that directory (because of the `src` setting) will appear with `../` segments.
-
-## Requirements
-
-- .NET 7 SDK (or newer) to build and run the console application.
-- File system access to the directories referenced by the `src` values inside `docfx.json`.
-- Network access is **not** required; all file resolution happens locally.
-
-## Notes
-
-The parser only reports references that resolve to files declared in the `docfx.json` file mappings. External links (HTTP/HTTPS), anchors, `mailto:` links, and `xref:` references are ignored.


### PR DESCRIPTION
## Summary
- refactor dependency registration to share file tracking logic across mapping sources
- include global metadata, file metadata, and template inputs when expanding dependencies from docfx.json
- extend the build configuration model to bind the additional docfx file collections

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ddaeaaa64c832398362bd83692ba9d